### PR TITLE
:source-dirs -> :source-paths in project.clj

### DIFF
--- a/docs/tutorials/creating-a-project.md
+++ b/docs/tutorials/creating-a-project.md
@@ -41,7 +41,7 @@ Edit the `project.clj` file to contain the following contents:
                  [org.arachne-framework/arachne-core "<arachne-core-version>"]
                  [datascript "0.15.5"]
                  [ch.qos.logback/logback-classic "1.1.3"]]
-  :source-dirs ["src" "config"]
+  :source-paths ["src" "config"]
   :repositories [["arachne-dev"
                   "http://maven.arachne-framework.org/artifactory/arachne-dev"]])
 ````


### PR DESCRIPTION
I could not run (arachne/config ...) with :source-dirs. Its already :source-paths in the arachne-docs project code.