### PR TITLE
fix lein setting to put config dir on classpath

### DIFF
--- a/docs/tutorials/creating-a-project.md
+++ b/docs/tutorials/creating-a-project.md
@@ -41,7 +41,7 @@ Edit the `project.clj` file to contain the following contents:
                  [org.arachne-framework/arachne-core "<arachne-core-version>"]
                  [datascript "0.15.5"]
                  [ch.qos.logback/logback-classic "1.1.3"]]
-  :source-dirs ["src" "config"]
+  :source-paths ["src" "config"]
   :repositories [["arachne-dev"
                   "http://maven.arachne-framework.org/artifactory/arachne-dev"]])
 ````


### PR DESCRIPTION
Arachne tutorial threw exception with this message: `Could not find config namespace myproj.config`

Changing a lein setting in `project.clj` fixed issue.

We might consider using `:resource-paths` instead to further denote that config files are not intended to be source files, but I'll defer to others on this final point.