### PR TITLE
Make docs more responsive with line wraps

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -42,3 +42,12 @@ aside {
 .rst-versions {
    display: none;
 }
+
+  /* Make docs responsive by line wrapping inside pre elements */
+  pre {
+    white-space: pre-wrap;       /* Since CSS 2.1 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}


### PR DESCRIPTION
Most code editors line wrap long lines. Codox doesn't line wrap inside pre tags by default. This PR causes all content inside pre elements to line wrap as per [this SO answer](http://stackoverflow.com/a/248013/2722254).