### PR TITLE
Fix ns and add ns

### DIFF
--- a/docs/tutorials/dependency-injection.md
+++ b/docs/tutorials/dependency-injection.md
@@ -114,7 +114,7 @@ Now, all that remains is to actually implement the `:myproj.core/robot` handler 
 
 Because we defined it in the handler dependency map, we know that we'll have a `:hash-component` key available in each request, with our robot-building component as its value.
 
-We just need to invoke the `myproj.value-hash/vhash` protocol function on our component and the string we want to hash, to get an `InputStream` that we can return as the request body.
+We just need to invoke the `myproj.visual-hash/vhash` protocol function on our component and the string we want to hash, to get an `InputStream` that we can return as the request body.
 
 ````clojure
 (defn robot
@@ -123,7 +123,7 @@ We just need to invoke the `myproj.value-hash/vhash` protocol function on our co
         c (:hash-component req)]
     {:status 200
      :headers {"Content-Type" "image/png"}
-     :body (vhash c name)}))
+     :body (myproj.visual/vhash c name)}))
 ````
 
 We'll also need to set the content-type header, so the browser knows what kind of a byte stream we're sending it (we happen to know it's a PNG image.)


### PR DESCRIPTION
Change `value-hash` to `visual-hash` in descriptive prose, but most importantly add namespace to unqualified symbol which caused exception. The other option would be to add it to the ns form for better style, but this works to illustrate the fix.


Ignore 3rd change which starts with "The point is". Sorry about these. I'll figure out what's happening with GH soon. My other PR's are plagued with this distraction too. 